### PR TITLE
Add shadow term relationships to all post types by default

### DIFF
--- a/src/Init.php
+++ b/src/Init.php
@@ -103,6 +103,8 @@ class Init {
 			$organizational->publications = new Publications();
 			$organizational->publications->register();
 		}
+
+		$organizational->register_relationships();
 	}
 
 	/**

--- a/src/Organizational.php
+++ b/src/Organizational.php
@@ -43,4 +43,48 @@ class Organizational {
 	 * Constructor.
 	 */
 	public function __construct() {}
+
+	/**
+	 * Enable Shadow Terms to supported post types.
+	 */
+	public function register_relationships(): void {
+
+		$relatives = [];
+
+		if ( isset( $this->people ) ) {
+			$relatives[] = $this->people->post_type;
+		}
+
+		if ( isset( $this->entities ) ) {
+			$relatives[] = $this->entities->post_type;
+		}
+
+		if ( isset( $this->projects ) ) {
+			$relatives[] = $this->projects->post_type;
+		}
+
+		if ( isset( $this->publications ) ) {
+			$relatives[] = $this->publications->post_type;
+		}
+
+		foreach ( $relatives as $post_type ) {
+			/**
+			 * Filter post types that can be related to a given post type via
+			 * its shadow term.
+			 *
+			 * @param array $relatives The related post types.
+			 */
+			$related = apply_filters( 'organizational_related_post_types_' . $post_type, array_diff( $relatives, [ $post_type ] ) );
+
+			if ( empty( $related ) ) {
+				continue;
+			}
+
+			add_post_type_support(
+				$post_type,
+				'shadow-terms',
+				$related
+			);
+		}
+	}
 }


### PR DESCRIPTION
This only matters if [Shadow Terms](https://github.com/happyprime/shadow-terms) is activated alongside this plugin