### PR TITLE
Add optional taxonomies to content types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,4 +2,6 @@ includes:
   - %rootDir%/../../happyprime/coding-standards/phpstan.neon.dist
 
 parameters:
-  level: 5
+  level: 8
+  ignoreErrors:
+    - identifier: missingType.iterableValue

--- a/plugin.php
+++ b/plugin.php
@@ -19,9 +19,8 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'ORGANIZATIONAL_VERSION', '2.2.0' );
-define( 'ORGANIZATIONAL_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'ORGANIZATIONAL_PLUGIN_FILE', __FILE__ );
+const VERSION = '2.2.0';
+const PLUGIN_FILE = __FILE__;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-const VERSION = '2.2.0';
+const VERSION     = '2.2.0';
 const PLUGIN_FILE = __FILE__;
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -109,6 +109,29 @@ class Admin {
 	}
 
 	/**
+	 * Render a settings field for a content type's singular and plural names.
+	 *
+	 * @param string $post_type Post type.
+	 * @param string $label Label.
+	 * @param string $value Value.
+	 * @param string $type Type.
+	 */
+	public static function render_content_type_field( string $post_type, string $label, string $value, string $type ): void {
+		?>
+			<div>
+				<label for="<?php echo esc_attr( self::get_id( $post_type, $type ) ); ?>"><?php echo esc_html( $label ); ?></label>
+				<input
+					id="<?php echo esc_attr( self::get_id( $post_type, $type ) ); ?>"
+					name="<?php echo esc_attr( self::get_name( $post_type, $type ) ); ?>"
+					value="<?php echo esc_attr( $value ); ?>"
+					type="text"
+					class="regular-text"
+				/>
+			</div>
+		<?php
+	}
+
+	/**
 	 * Output the settings fields for the Organizational plugin.
 	 */
 	public static function general_settings_names(): void {
@@ -181,101 +204,27 @@ class Admin {
 		<div class="organizational-settings-names">
 			<p>Changing the settings here will override the default labels for the content types provided by the Organizational plugin. The default labels are listed to the left of each field. The <strong>singular</strong> label will also be used as a slug in URLs.</p>
 
-			<?php if ( isset( $organizational->projects ) ) : ?>
-			<div>
-				<label for="<?php echo esc_attr( self::get_id( $organizational->projects->post_type, 'singular' ) ); ?>">Project (Singular)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->projects->post_type, 'singular' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->projects->post_type, 'singular' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->projects->post_type ]['singular'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
+			<?php
+			if ( isset( $organizational->projects ) ) {
+				self::render_content_type_field( $organizational->projects->post_type, 'Project (Singular)', $display_names[ $organizational->projects->post_type ]['singular'], 'singular' );
+				self::render_content_type_field( $organizational->projects->post_type, 'Projects (Plural)', $display_names[ $organizational->projects->post_type ]['plural'], 'plural' );
+			}
 
-			<div>
-				<label for="<?php echo esc_attr( self::get_id( $organizational->projects->post_type, 'plural' ) ); ?>">Projects (Plural)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->projects->post_type, 'plural' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->projects->post_type, 'plural' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->projects->post_type ]['plural'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-			<?php endif; ?>
+			if ( isset( $organizational->people ) ) {
+				self::render_content_type_field( $organizational->people->post_type, 'Person (Singular)', $display_names[ $organizational->people->post_type ]['singular'], 'singular' );
+				self::render_content_type_field( $organizational->people->post_type, 'People (Plural)', $display_names[ $organizational->people->post_type ]['plural'], 'plural' );
+			}
 
-			<?php if ( isset( $organizational->people ) ) : ?>
-			<div>
-				<label for="organizational_names_people_singular">Person (Singular)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->people->post_type, 'singular' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->people->post_type, 'singular' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->people->post_type ]['singular'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
+			if ( isset( $organizational->entities ) ) {
+				self::render_content_type_field( $organizational->entities->post_type, 'Entity (Singular)', $display_names[ $organizational->entities->post_type ]['singular'], 'singular' );
+				self::render_content_type_field( $organizational->entities->post_type, 'Entities (Plural)', $display_names[ $organizational->entities->post_type ]['plural'], 'plural' );
+			}
 
-			<div>
-				<label for="organizational_names_people_plural">People (Plural)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->people->post_type, 'plural' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->people->post_type, 'plural' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->people->post_type ]['plural'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-			<?php endif; ?>
-
-			<?php if ( isset( $organizational->entities ) ) : ?>
-			<div>
-				<label for="organizational_names_entity_singular">Entity (Singular)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->entities->post_type, 'singular' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->entities->post_type, 'singular' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->entities->post_type ]['singular'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-
-			<div>
-				<label for="organizational_names_entity_plural">Entities (Plural)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->entities->post_type, 'plural' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->entities->post_type, 'plural' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->entities->post_type ]['plural'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-			<?php endif; ?>
-
-			<?php if ( isset( $organizational->publications ) ) : ?>
-			<div>
-				<label for="organizational_names_publication_singular">Publication (Singular)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->publications->post_type, 'singular' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->publications->post_type, 'singular' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->publications->post_type ]['singular'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-
-			<div>
-				<label for="organizational_names_publication_plural">Publications (Plural)</label>
-				<input
-					id="<?php echo esc_attr( self::get_id( $organizational->publications->post_type, 'plural' ) ); ?>"
-					name="<?php echo esc_attr( self::get_name( $organizational->publications->post_type, 'plural' ) ); ?>"
-					value="<?php echo esc_attr( $display_names[ $organizational->publications->post_type ]['plural'] ); ?>"
-					type="text"
-					class="regular-text"
-				/>
-			</div>
-			<?php endif; ?>
+			if ( isset( $organizational->publications ) ) {
+				self::render_content_type_field( $organizational->publications->post_type, 'Publication (Singular)', $display_names[ $organizational->publications->post_type ]['singular'], 'singular' );
+				self::render_content_type_field( $organizational->publications->post_type, 'Publications (Plural)', $display_names[ $organizational->publications->post_type ]['plural'], 'plural' );
+			}
+			?>
 		</div>
 		<?php
 	}

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -16,29 +16,112 @@ class Admin {
 	 * Initialize customizations in the WordPress admin.
 	 */
 	public static function init(): void {
+		add_action( 'admin_menu', array( __CLASS__, 'add_settings_page' ) );
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+	}
+
+	/**
+	 * Add the settings page to the WordPress admin menu.
+	 */
+	public static function add_settings_page(): void {
+		add_options_page(
+			'Organizational Settings',
+			'Organizational',
+			'manage_options',
+			'organizational-settings',
+			array( __CLASS__, 'render_settings_page' )
+		);
 	}
 
 	/**
 	 * Register plugin settings fields.
 	 */
 	public static function register_settings(): void {
+		global $organizational;
+
 		register_setting(
-			'general',
+			'organizational_settings',
 			'organizational_names',
 			array( __CLASS__, 'sanitize_names' )
 		);
 
-		add_settings_field(
-			'organizational-names',
-			'Organizational Names',
-			array( __CLASS__, 'general_settings_names' ),
-			'general',
-			'default',
-			array(
-				'label_for' => 'organizational_names',
-			)
+		add_settings_section(
+			'organizational_names_section',
+			'Content Type Names',
+			array( __CLASS__, 'render_names_section' ),
+			'organizational-settings'
 		);
+
+		$content_types = $organizational->get_content_types();
+
+		foreach ( $content_types as $content_type ) {
+			add_settings_field(
+				'organizational-names-' . $content_type->post_type,
+				$content_type->default_name,
+				array( __CLASS__, 'general_settings_names' ),
+				'organizational-settings',
+				'organizational_names_section',
+				array(
+					'content_type' => $content_type,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Render the settings page.
+	 */
+	public static function render_settings_page(): void {
+		?>
+		<div class="wrap">
+			<h1>Organizational Settings</h1>
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( 'organizational_settings' );
+				do_settings_sections( 'organizational-settings' );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the content type names section.
+	 */
+	public static function render_names_section(): void {
+		?>
+		<p>Changing the settings here will override the default labels for the content types
+			provided by the Organizational plugin. The default labels are listed to the left
+			of each field. The <strong>singular</strong> label will also be used as a slug
+			in URLs.</p>
+		<style>
+			.organizational-settings-names {
+
+				.og-content-type-section {
+					margin-bottom: 1rem;
+
+					div {
+						display: flex;
+						margin-bottom: 0.5rem;
+
+						* {
+							flex-basis: 150px;
+						}
+					}
+				}
+
+				.checkbox:not(:checked) ~ label ~ .og-taxonomy-section {
+					display: none;
+				}
+
+				.checkbox:checked ~ label ~ .og-taxonomy-section {
+					display: block;
+					margin-top: 1rem;
+				}
+			}
+		</style>
+		<?php
 	}
 
 	/**
@@ -51,22 +134,11 @@ class Admin {
 	public static function sanitize_names( $names ): array {
 		global $organizational;
 
+		$content_types        = $organizational->get_content_types();
 		$supported_post_types = array();
 
-		if ( isset( $organizational->projects ) ) {
-			$supported_post_types[] = $organizational->projects->post_type;
-		}
-
-		if ( isset( $organizational->people ) ) {
-			$supported_post_types[] = $organizational->people->post_type;
-		}
-
-		if ( isset( $organizational->entities ) ) {
-			$supported_post_types[] = $organizational->entities->post_type;
-		}
-
-		if ( isset( $organizational->publications ) ) {
-			$supported_post_types[] = $organizational->publications->post_type;
+		foreach ( $content_types as $content_type ) {
+			$supported_post_types[] = $content_type->post_type;
 		}
 
 		$clean_names = array();
@@ -75,8 +147,14 @@ class Admin {
 				continue;
 			}
 
-			$clean_names[ $name ]['singular'] = sanitize_text_field( $data['singular'] );
-			$clean_names[ $name ]['plural']   = sanitize_text_field( $data['plural'] );
+			$clean_names[ $name ]['singular']          = sanitize_text_field( $data['singular'] );
+			$clean_names[ $name ]['plural']            = sanitize_text_field( $data['plural'] );
+			$clean_names[ $name ]['taxonomy_singular'] = sanitize_text_field( $data['taxonomy_singular'] );
+			$clean_names[ $name ]['taxonomy_plural']   = sanitize_text_field( $data['taxonomy_plural'] );
+
+			if ( isset( $data['taxonomy-toggle'] ) ) {
+				$clean_names[ $name ]['taxonomy_toggle'] = 1;
+			}
 		}
 
 		wp_schedule_single_event( time() + 1, 'organizational_flush_rewrite_rules' );
@@ -87,8 +165,8 @@ class Admin {
 	/**
 	 * Get the name attribute for a settings field.
 	 *
-	 * @param string $post_type Post type.
-	 * @param string $name Field name.
+	 * @param string $post_type The content type's post type.
+	 * @param string $name      The field's name.
 	 *
 	 * @return string Name attribute.
 	 */
@@ -99,8 +177,8 @@ class Admin {
 	/**
 	 * Get the ID attribute for a settings field.
 	 *
-	 * @param string $post_type Post type.
-	 * @param string $name Field name.
+	 * @param string $post_type The content type's post type.
+	 * @param string $name      The field's name.
 	 *
 	 * @return string ID attribute.
 	 */
@@ -111,10 +189,10 @@ class Admin {
 	/**
 	 * Render a settings field for a content type's singular and plural names.
 	 *
-	 * @param string $post_type Post type.
-	 * @param string $label Label.
-	 * @param string $value Value.
-	 * @param string $type Type.
+	 * @param string $post_type The content type's post type.
+	 * @param string $label     The field's label.
+	 * @param string $value     The field's current value.
+	 * @param string $type      Whether the field is for the content type's singular or plural name.
 	 */
 	public static function render_content_type_field( string $post_type, string $label, string $value, string $type ): void {
 		?>
@@ -132,99 +210,96 @@ class Admin {
 	}
 
 	/**
-	 * Output the settings fields for the Organizational plugin.
+	 * Render a settings field to toggle whether an additional taxonomy is
+	 * registered for a content type.
+	 *
+	 * @param string $post_type The content type's post type.
+	 * @param string $label     The label text for the toggle.
+	 * @param int    $value     Whether the toggle is checked.
 	 */
-	public static function general_settings_names(): void {
-		global $organizational;
+	public static function render_taxonomy_toggle( string $post_type, string $label, int $value ): void {
+		?>
+		<input
+			id="<?php echo esc_attr( self::get_id( $post_type, 'taxonomy-toggle' ) ); ?>"
+			name="<?php echo esc_attr( self::get_name( $post_type, 'taxonomy-toggle' ) ); ?>"
+			type="checkbox"
+			value="1"
+			class="checkbox"
+			<?php checked( $value, 1 ); ?>
+		/>
+		<label for="<?php echo esc_attr( self::get_id( $post_type, 'taxonomy-toggle' ) ); ?>"><?php echo esc_html( $label ); ?></label>
+		<?php
+	}
 
-		if ( ! isset( $organizational ) || ! is_object( $organizational ) ) {
+	/**
+	 * Render a settings field to capture the name of an additional taxonomy
+	 * for a content type.
+	 *
+	 * @param string $post_type The content type's post type.
+	 * @param string $label     The field's label.
+	 * @param string $value     The field's current value.
+	 * @param string $type      Whether the field is for the taxonomy's singular or plural name.
+	 */
+	public static function render_taxonomy_field( string $post_type, string $label, string $value, string $type ): void {
+		?>
+			<div>
+				<label for="<?php echo esc_attr( self::get_id( $post_type, $type ) ); ?>"><?php echo esc_html( $label ); ?></label>
+				<input
+					id="<?php echo esc_attr( self::get_id( $post_type, $type ) ); ?>"
+					name="<?php echo esc_attr( self::get_name( $post_type, $type ) ); ?>"
+					type="text"
+					class="regular-text"
+					value="<?php echo esc_attr( $value ); ?>"
+				/>
+			</div>
+		<?php
+	}
+
+	/**
+	 * Output the settings fields for the Organizational plugin.
+	 *
+	 * @param array $args Arguments passed to the callback function.
+	 */
+	public static function general_settings_names( $args ): void {
+		if ( ! isset( $args['content_type'] ) ) {
 			return;
 		}
 
-		$names = get_option( 'organizational_names', false );
-
+		$content_type  = $args['content_type'];
+		$names         = get_option( 'organizational_names', false );
 		$display_names = array();
 
-		if ( isset( $organizational->projects ) && ! isset( $names[ $organizational->projects->post_type ] ) ) {
-			$names[ $organizational->projects->post_type ] = array();
+		if ( ! isset( $names[ $content_type->post_type ] ) ) {
+			$names[ $content_type->post_type ] = array();
 		}
 
-		if ( isset( $organizational->people ) && ! isset( $names[ $organizational->people->post_type ] ) ) {
-			$names[ $organizational->people->post_type ] = array();
-		}
+		$display_names[ $content_type->post_type ] = wp_parse_args(
+			$names[ $content_type->post_type ],
+			array(
+				'singular'          => $content_type->singular_name,
+				'plural'            => $content_type->plural_name,
+				'taxonomy_singular' => $content_type->taxonomy_singular_name,
+				'taxonomy_plural'   => $content_type->taxonomy_plural_name,
+			)
+		);
 
-		if ( isset( $organizational->entities ) && ! isset( $names[ $organizational->entities->post_type ] ) ) {
-			$names[ $organizational->entities->post_type ] = array();
-		}
+		$taxonomy_toggle = isset( $display_names[ $content_type->post_type ]['taxonomy_toggle'] ) ? (int) $display_names[ $content_type->post_type ]['taxonomy_toggle'] : 0;
 
-		if ( isset( $organizational->publications ) && ! isset( $names[ $organizational->publications->post_type ] ) ) {
-			$names[ $organizational->publications->post_type ] = array();
-		}
-
-		if ( isset( $organizational->projects ) ) {
-			$display_names[ $organizational->projects->post_type ] = wp_parse_args(
-				$names[ $organizational->projects->post_type ],
-				array(
-					'singular' => $organizational->projects->singular_name,
-					'plural'   => $organizational->projects->plural_name,
-				)
-			);
-		}
-
-		if ( isset( $organizational->people ) ) {
-			$display_names[ $organizational->people->post_type ] = wp_parse_args(
-				$names[ $organizational->people->post_type ],
-				array(
-					'singular' => $organizational->people->singular_name,
-					'plural'   => $organizational->people->plural_name,
-				)
-			);
-		}
-
-		if ( isset( $organizational->entities ) ) {
-			$display_names[ $organizational->entities->post_type ] = wp_parse_args(
-				$names[ $organizational->entities->post_type ],
-				array(
-					'singular' => $organizational->entities->singular_name,
-					'plural'   => $organizational->entities->plural_name,
-				)
-			);
-		}
-
-		if ( isset( $organizational->publications ) ) {
-			$display_names[ $organizational->publications->post_type ] = wp_parse_args(
-				$names[ $organizational->publications->post_type ],
-				array(
-					'singular' => $organizational->publications->singular_name,
-					'plural'   => $organizational->publications->plural_name,
-				)
-			);
-		}
 		?>
 		<div class="organizational-settings-names">
-			<p>Changing the settings here will override the default labels for the content types provided by the Organizational plugin. The default labels are listed to the left of each field. The <strong>singular</strong> label will also be used as a slug in URLs.</p>
-
-			<?php
-			if ( isset( $organizational->projects ) ) {
-				self::render_content_type_field( $organizational->projects->post_type, 'Project (Singular)', $display_names[ $organizational->projects->post_type ]['singular'], 'singular' );
-				self::render_content_type_field( $organizational->projects->post_type, 'Projects (Plural)', $display_names[ $organizational->projects->post_type ]['plural'], 'plural' );
-			}
-
-			if ( isset( $organizational->people ) ) {
-				self::render_content_type_field( $organizational->people->post_type, 'Person (Singular)', $display_names[ $organizational->people->post_type ]['singular'], 'singular' );
-				self::render_content_type_field( $organizational->people->post_type, 'People (Plural)', $display_names[ $organizational->people->post_type ]['plural'], 'plural' );
-			}
-
-			if ( isset( $organizational->entities ) ) {
-				self::render_content_type_field( $organizational->entities->post_type, 'Entity (Singular)', $display_names[ $organizational->entities->post_type ]['singular'], 'singular' );
-				self::render_content_type_field( $organizational->entities->post_type, 'Entities (Plural)', $display_names[ $organizational->entities->post_type ]['plural'], 'plural' );
-			}
-
-			if ( isset( $organizational->publications ) ) {
-				self::render_content_type_field( $organizational->publications->post_type, 'Publication (Singular)', $display_names[ $organizational->publications->post_type ]['singular'], 'singular' );
-				self::render_content_type_field( $organizational->publications->post_type, 'Publications (Plural)', $display_names[ $organizational->publications->post_type ]['plural'], 'plural' );
-			}
-			?>
+			<div class="og-content-type-section">
+				<?php
+				self::render_content_type_field( $content_type->post_type, 'Singular', $display_names[ $content_type->post_type ]['singular'], 'singular' );
+				self::render_content_type_field( $content_type->post_type, 'Plural', $display_names[ $content_type->post_type ]['plural'], 'plural' );
+				self::render_taxonomy_toggle( $content_type->post_type, 'Enable additional taxonomy for ' . $content_type->default_name, $taxonomy_toggle );
+				?>
+				<div class="og-taxonomy-section">
+					<?php
+					self::render_taxonomy_field( $content_type->post_type, 'Singular', $display_names[ $content_type->post_type ]['taxonomy_singular'], 'taxonomy_singular' );
+					self::render_taxonomy_field( $content_type->post_type, 'Plural', $display_names[ $content_type->post_type ]['taxonomy_plural'], 'taxonomy_plural' );
+					?>
+				</div>
+			</div>
 		</div>
 		<?php
 	}

--- a/src/ContentType.php
+++ b/src/ContentType.php
@@ -12,7 +12,7 @@ namespace HappyPrime\Organizational;
  */
 class ContentType {
 	/**
-	 * The post type.
+	 * The post type slug.
 	 *
 	 * @var string
 	 */
@@ -47,6 +47,34 @@ class ContentType {
 	public string $plural_name = '';
 
 	/**
+	 * Whether the additional taxonomy is active.
+	 *
+	 * @var bool
+	 */
+	public bool $taxonomy_active = false;
+
+	/**
+	 * The slug for an additional taxonomy associated with the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy = '';
+
+	/**
+	 * The plural name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_plural_name = '';
+
+	/**
+	 * The singular name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_singular_name = '';
+
+	/**
 	 * Meta fields automatically registered for the post type.
 	 *
 	 * @since 2.1.0
@@ -66,6 +94,10 @@ class ContentType {
 		register_post_type( $this->post_type, $this->get_args() );
 
 		$this->register_meta();
+
+		if ( $this->taxonomy_active ) {
+			$this->register_taxonomy();
+		}
 	}
 
 	/**
@@ -96,6 +128,15 @@ class ContentType {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Register the additional taxonomy for the content type.
+	 *
+	 * @return void
+	 */
+	public function register_taxonomy(): void {
+		register_taxonomy( $this->taxonomy, $this->post_type, $this->get_taxonomy_args() );
 	}
 
 	/**
@@ -169,6 +210,41 @@ class ContentType {
 	}
 
 	/**
+	 * Retrieve the arguments for taxonomy registration.
+	 *
+	 * @return array
+	 */
+	public function get_taxonomy_args(): array {
+		$args = array(
+			'label'                 => $this->taxonomy_plural_name,
+			'labels'                => array(
+				'name'          => $this->taxonomy_plural_name,
+				'singular_name' => $this->taxonomy_singular_name,
+			),
+			'public'                => true,
+			'publicly_queryable'    => true,
+			'hierarchical'          => true,
+			'show_ui'               => true,
+			'show_in_menu'          => true,
+			'show_in_nav_menus'     => true,
+			'query_var'             => true,
+			'rewrite'               => array(
+				'slug'       => sanitize_title( strtolower( $this->taxonomy_singular_name ) ),
+				'with_front' => true,
+			),
+			'show_admin_column'     => true,
+			'show_in_rest'          => true,
+			'rest_base'             => sanitize_title( strtolower( $this->taxonomy_plural_name ) ),
+			'rest_controller_class' => 'WP_REST_Terms_Controller',
+			'show_in_quick_edit'    => true,
+		);
+
+		$args = apply_filters( "organizational_{$this->post_type}_taxonomy_args", $args );
+
+		return $args;
+	}
+
+	/**
 	 * Retrieve object type names from a previously saved names option.
 	 *
 	 * @return array A list of singular and plural names.
@@ -184,11 +260,26 @@ class ContentType {
 			$this->plural_name = $names[ $this->post_type ]['plural'] ? $names[ $this->post_type ]['plural'] : $this->plural_name;
 		}
 
+		if ( false !== $names && isset( $names[ $this->post_type ] ) && isset( $names[ $this->post_type ]['taxonomy_singular'] ) ) {
+			$this->taxonomy_singular_name = $names[ $this->post_type ]['taxonomy_singular'] ? $names[ $this->post_type ]['taxonomy_singular'] : $this->taxonomy_singular_name;
+		}
+
+		if ( false !== $names && isset( $names[ $this->post_type ] ) && isset( $names[ $this->post_type ]['taxonomy_plural'] ) ) {
+			$this->taxonomy_plural_name = $names[ $this->post_type ]['taxonomy_plural'] ? $names[ $this->post_type ]['taxonomy_plural'] : $this->taxonomy_plural_name;
+		}
+
+		if ( false !== $names && isset( $names[ $this->post_type ] ) && isset( $names[ $this->post_type ]['taxonomy_toggle'] ) ) {
+			$this->taxonomy_active = $names[ $this->post_type ]['taxonomy_toggle'] ? true : false;
+		}
+
 		return apply_filters(
 			"organizational_{$this->post_type}_type_names",
 			array(
-				'singular' => $this->singular_name,
-				'plural'   => $this->plural_name,
+				'singular'          => $this->singular_name,
+				'plural'            => $this->plural_name,
+				'taxonomy_active'   => $this->taxonomy_active,
+				'taxonomy_singular' => $this->taxonomy_singular_name,
+				'taxonomy_plural'   => $this->taxonomy_plural_name,
 			)
 		);
 	}

--- a/src/Entities.php
+++ b/src/Entities.php
@@ -19,6 +19,16 @@ class Entities extends ContentType {
 	public string $post_type = 'og_entity';
 
 	/**
+	 * The default name.
+	 *
+	 * Used to refer to the content type in the admin settings even after the
+	 * name has been overridden.
+	 *
+	 * @var string
+	 */
+	public string $default_name = 'Entities';
+
+	/**
 	 * The singular name.
 	 *
 	 * @var string
@@ -38,4 +48,25 @@ class Entities extends ContentType {
 	 * @var string
 	 */
 	public string $menu_icon = 'dashicons-groups';
+
+	/**
+	 * The slug for an additional taxonomy associated with the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy = 'og_entity_group';
+
+	/**
+	 * The plural name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_plural_name = 'Entity Groups';
+
+	/**
+	 * The singular name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_singular_name = 'Entity Group';
 }

--- a/src/Init.php
+++ b/src/Init.php
@@ -55,7 +55,7 @@ class Init {
 			flush_rewrite_rules();
 		}
 
-		update_option( 'organizational_version', ORGANIZATIONAL_VERSION );
+		update_option( 'organizational_version', VERSION );
 	}
 
 	/**

--- a/src/Init.php
+++ b/src/Init.php
@@ -117,20 +117,8 @@ class Init {
 			return;
 		}
 
-		if ( current_theme_supports( 'organizational_person' ) ) {
-			$organizational->people->enqueue_block_editor_assets();
-		}
-
-		if ( current_theme_supports( 'organizational_project' ) ) {
-			$organizational->projects->enqueue_block_editor_assets();
-		}
-
-		if ( current_theme_supports( 'organizational_entity' ) ) {
-			$organizational->entities->enqueue_block_editor_assets();
-		}
-
-		if ( current_theme_supports( 'organizational_publication' ) ) {
-			$organizational->publications->enqueue_block_editor_assets();
+		foreach ( $organizational->get_content_types() as $content_type ) {
+			$content_type->enqueue_block_editor_assets();
 		}
 	}
 }

--- a/src/Organizational.php
+++ b/src/Organizational.php
@@ -45,6 +45,20 @@ class Organizational {
 	public function __construct() {}
 
 	/**
+	 * Retrieve supported content types for the site.
+	 *
+	 * @return ContentType[]
+	 */
+	public function get_content_types(): array {
+		return array_filter(
+			get_object_vars( $this ),
+			function ( $property ) {
+				return $property instanceof ContentType;
+			}
+		);
+	}
+
+	/**
 	 * Enable Shadow Terms to supported post types.
 	 *
 	 * @since 2.0.1

--- a/src/People.php
+++ b/src/People.php
@@ -198,7 +198,7 @@ class People extends ContentType {
 	 * Enqueue block editor assets used by this post type.
 	 */
 	public function enqueue_block_editor_assets(): void {
-		if ( 'post' !== get_current_screen()->base || get_current_screen()->post_type !== $this->post_type ) {
+		if ( ! get_current_screen() || 'post' !== get_current_screen()->base || get_current_screen()->post_type !== $this->post_type ) {
 			return;
 		}
 

--- a/src/People.php
+++ b/src/People.php
@@ -19,6 +19,16 @@ class People extends ContentType {
 	public string $post_type = 'og_person';
 
 	/**
+	 * The default name.
+	 *
+	 * Used to refer to the content type in the admin settings even after the
+	 * name has been overridden.
+	 *
+	 * @var string
+	 */
+	public string $default_name = 'People';
+
+	/**
 	 * The singular name.
 	 *
 	 * @var string
@@ -38,6 +48,27 @@ class People extends ContentType {
 	 * @var string
 	 */
 	public string $menu_icon = 'dashicons-id-alt';
+
+	/**
+	 * The slug for an additional taxonomy associated with the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy = 'og_person_group';
+
+	/**
+	 * The plural name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_plural_name = 'People Groups';
+
+	/**
+	 * The singular name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_singular_name = 'People Group';
 
 	/**
 	 * Meta keys automatically registered for the post type.

--- a/src/People.php
+++ b/src/People.php
@@ -202,11 +202,11 @@ class People extends ContentType {
 			return;
 		}
 
-		$asset_data = require_once ORGANIZATIONAL_PLUGIN_DIR . '/js/build/people-meta/index.asset.php';
+		$asset_data = require_once plugin_dir_path( PLUGIN_FILE ) . '/js/build/people-meta/index.asset.php';
 
 		wp_enqueue_script(
 			'organizational-people-meta',
-			plugins_url( '/js/build/people-meta/index.js', ORGANIZATIONAL_PLUGIN_FILE ),
+			plugins_url( '/js/build/people-meta/index.js', PLUGIN_FILE ),
 			$asset_data['dependencies'],
 			$asset_data['version'],
 			true

--- a/src/Projects.php
+++ b/src/Projects.php
@@ -19,6 +19,16 @@ class Projects extends ContentType {
 	public string $post_type = 'og_project';
 
 	/**
+	 * The default name.
+	 *
+	 * Used to refer to the content type in the admin settings even after the
+	 * name has been overridden.
+	 *
+	 * @var string
+	 */
+	public string $default_name = 'Projects';
+
+	/**
 	 * The singular name.
 	 *
 	 * @var string
@@ -38,4 +48,25 @@ class Projects extends ContentType {
 	 * @var string
 	 */
 	public string $menu_icon = 'dashicons-analytics';
+
+	/**
+	 * The slug for an additional taxonomy associated with the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy = 'og_project_group';
+
+	/**
+	 * The plural name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_plural_name = 'Project Groups';
+
+	/**
+	 * The singular name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_singular_name = 'Project Group';
 }

--- a/src/Publications.php
+++ b/src/Publications.php
@@ -19,6 +19,16 @@ class Publications extends ContentType {
 	public string $post_type = 'og_publication';
 
 	/**
+	 * The default name.
+	 *
+	 * Used to refer to the content type in the admin settings even after the
+	 * name has been overridden.
+	 *
+	 * @var string
+	 */
+	public string $default_name = 'Publications';
+
+	/**
 	 * The singular name.
 	 *
 	 * @var string
@@ -38,6 +48,27 @@ class Publications extends ContentType {
 	 * @var string
 	 */
 	public string $menu_icon = 'dashicons-book';
+
+	/**
+	 * The slug for an additional taxonomy associated with the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy = 'og_publication_group';
+
+	/**
+	 * The plural name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_plural_name = 'Publication Groups';
+
+	/**
+	 * The singular name of an additional taxonomy for the content type.
+	 *
+	 * @var string
+	 */
+	public string $taxonomy_singular_name = 'Publication Group';
 
 	/**
 	 * Meta keys automatically registered for the post type.

--- a/src/Publications.php
+++ b/src/Publications.php
@@ -150,7 +150,7 @@ class Publications extends ContentType {
 	 * Enqueue block editor assets used by this post type.
 	 */
 	public function enqueue_block_editor_assets(): void {
-		if ( 'post' !== get_current_screen()->base || get_current_screen()->post_type !== $this->post_type ) {
+		if ( ! get_current_screen() || 'post' !== get_current_screen()->base || get_current_screen()->post_type !== $this->post_type ) {
 			return;
 		}
 

--- a/src/Publications.php
+++ b/src/Publications.php
@@ -154,11 +154,11 @@ class Publications extends ContentType {
 			return;
 		}
 
-		$asset_data = require_once ORGANIZATIONAL_PLUGIN_DIR . '/js/build/publication-meta/index.asset.php';
+		$asset_data = require_once plugin_dir_path( PLUGIN_FILE ) . '/js/build/publication-meta/index.asset.php';
 
 		wp_enqueue_script(
 			'organizational-publication-meta',
-			plugins_url( '/js/build/publication-meta/index.js', ORGANIZATIONAL_PLUGIN_FILE ),
+			plugins_url( '/js/build/publication-meta/index.js', PLUGIN_FILE ),
 			$asset_data['dependencies'],
 			$asset_data['version'],
 			true


### PR DESCRIPTION
* Move the settings screen for Organizational out of General and into its own view under Settings -> Organizational.
* Add a toggle to enable a taxonomy for each supported content type that can be used to group content of that type.
* Abstract a few more things to improve how the admin screen and other bits are managed.